### PR TITLE
Update paths to CSS

### DIFF
--- a/inc/header.php
+++ b/inc/header.php
@@ -5,10 +5,10 @@
 		<title>leDashboard</title>
 		<link rel="shortcut icon" href="dist/img/favicon.ico" />
 
-		<link rel="stylesheet" type="text/css" href="dist/style/css/flick/jquery-ui-1.10.3.custom.css">
+		<link rel="stylesheet" type="text/css" href="dist/css/flick/jquery-ui-1.10.3.custom.css">
 		
 		<!-- CSS includes -->
-		<link rel="stylesheet" href="dist/style/screen.css" />
+		<link rel="stylesheet" href="dist/css/screen.css" />
 
 	</head>
 


### PR DESCRIPTION
Dear Christian Jung,

Thank you for providing this dashboard. As igoogle seems to be closing soon, I am trying to install and use it :-)

I am having trouble to show images and css, because there seems to be some issues with CSS paths.

For instance here 5ab614c4f41bf7f21ef65eb0a439060f1752c20e you are using dist/img/... but the dist directory does not exist.

If I have understood your intentions properly, you want to keep all the themable stuff in src/style and then link it from dist. By doing this, anyone could create its own src/mystyle directory and use it simply by changing "dist".

Following this idea, in my local installation I have used:

```
ln -s src/style dist
```

In the root of leDashboard in order to create a directory named dist that points to src/style, as I want to use the default (and only) theme.

In inc/header.php you seem to be using dist/img/favicon.ico, dist/style/css/flick/... and dist/style/screen.css.

If I am not mistaken, these paths are not consistent and they should be as follows:
- dist/img/favicon.ico --> OK
- dist/style/css/flick/... --> dist/css/flick/...
- dist/style/screen.css --> dist/css/flick/...

This pull request fixes both things. If hope I have understood your intentions, and this patch is helping. Otherwise, forgive me for wasting your time :-)

Thanks

Sergio
