### PR TITLE
[Fix] Preserve protocol on font to avoid mixed https/http content

### DIFF
--- a/src/style/less/screen.less
+++ b/src/style/less/screen.less
@@ -1,4 +1,4 @@
-@import url( "http://fonts.googleapis.com/css?family=Droid+Sans:400,700" );
+@import url( "//fonts.googleapis.com/css?family=Droid+Sans:400,700" );
 /**
  *	leDashboard Desktop-Styles
  **/


### PR DESCRIPTION
On HTTPS a mixed content [1] warning was raised due to this import.

[1] https://developer.mozilla.org/ca/docs/Security/MixedContent
